### PR TITLE
Fixed background dark outline

### DIFF
--- a/src/app/components/BackgroundComponent.tsx
+++ b/src/app/components/BackgroundComponent.tsx
@@ -21,5 +21,5 @@ export default function BackgroundComponent({character} : {character: ICharacter
             break;
             
     }
-    return <div className={"-z-10 fixed w-screen h-screen top-0 left-0 bg-cover blur-md ".concat(bg)} ></div>
+    return <div className={"-z-10 fixed w-screen h-screen top-0 left-0 bg-cover scale-105 blur-md ".concat(bg)}></div>
 }


### PR DESCRIPTION
**Motivations:**
Since blurring a background image also blurs its outline, this results in a disgraceful outline all around it.

**What has been modified:**
I just added `scale-105` to scale the background images by 5% more. This is almost not noticable, but also does remove the outline. Note that according to https://stackoverflow.com/a/60492357, another solution would be to use `backdrop-filter` (also available with [Tailwind](https://tailwindcss.com/docs/backdrop-blur)) on a div placed in front of it.

**Before:**
![image](https://github.com/eikofee/eikonomiya-front/assets/100100316/eeb24385-f18c-4c0d-9cfe-a60349318694)

**After:**
![image](https://github.com/eikofee/eikonomiya-front/assets/100100316/7e922b8c-cd3c-43c3-a396-b1fc69447627)
