### PR TITLE
Fixed `mkdir data`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY . .
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED 1
-RUN mkdir data
+RUN test -d data || mkdir data
 RUN yarn build
 
 # If using npm comment out above and use below instead


### PR DESCRIPTION
This is to address https://github.com/eikofee/eikonomiya/issues/6, which has been marked as closed altough the issue is still there.

The Docker image can now be (re-)built even if the `data/` folder already exists. The Dockerfile starts by testing if the folder already exists. If it does, then it does not try to create it again.